### PR TITLE
[FIX] 修复 HLTV 下半场小比分

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -42,8 +42,8 @@ const getMatch = async ({ id }: { id: number }): Promise<FullMatch> => {
         const result = mapEl.find('.results');
         const t_first = result.find('.t').first().text();
         const ct_first = result.find('.ct').first().text();
-        const t_second = result.find('.t').last().text() === t_first ? '' : result.find('.t').last().text();
-        const ct_second = result.find('.ct').last().text() === ct_first ? '' : result.find('.ct').last().text();
+        const t_second = result.find('.t').last().text();
+        const ct_second = result.find('.ct').last().text();
         return {
             name: getMapSlug(mapEl.find('.mapname').text()),
             result: result.text(),


### PR DESCRIPTION
当 CS:GO 一场比赛存在加时赛的情况下:
```
19:16 (7:8; 8:7) (4:1)
```
按照现有代码的逻辑下半场比分为空.

Solve: 移除错误的逻辑判断, 上下半场的比分正常.

PS: 加时赛的比赛不在此处处理